### PR TITLE
Fix message content for Gemini API

### DIFF
--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -34,6 +34,40 @@ from ..config import SELECTED_SEARCH_ENGINE, SearchEngine
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_messages(messages: list) -> list:
+    """Replace ``None`` content with an empty string.
+
+    Some language model providers (e.g. the OpenAI compatible Gemini API)
+    reject messages whose ``content`` field is ``null``. Tool call messages
+    created by upstream libraries may have ``content=None`` which leads to a
+    ``400`` response (``Expected string or list of content parts, got: null``).
+    This helper normalises such messages before they are sent to the model.
+    """
+
+    sanitized: list = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            if msg.get("content") is None:
+                msg = {**msg, "content": ""}
+            sanitized.append(msg)
+            continue
+
+        content = getattr(msg, "content", None)
+        if content is None:
+            try:
+                msg.content = ""
+            except Exception:
+                try:
+                    attrs = msg.__dict__.copy()
+                    attrs["content"] = ""
+                    msg = msg.__class__(**attrs)
+                except Exception:
+                    pass
+        sanitized.append(msg)
+
+    return sanitized
+
+
 @tool
 def handoff_to_planner(
     research_topic: Annotated[str, "The topic of the research task to be handed off."],
@@ -305,6 +339,10 @@ async def _execute_agent_step(
     state: State, agent, agent_name: str
 ) -> Command[Literal["research_team"]]:
     """Helper function to execute a step using the specified agent."""
+    # Sanitize conversation history to avoid ``null`` contents being passed to
+    # model providers that do not support them.
+    state["messages"] = _sanitize_messages(state.get("messages", []))
+
     current_plan = state.get("current_plan")
     observations = state.get("observations", [])
 


### PR DESCRIPTION
## Summary
- sanitize messages so null content doesn't break OpenAI-compatible endpoints

## Testing
- `python -m pytest -q -o addopts=` *(fails: ModuleNotFoundError: No module named 'markdownify')*

------
https://chatgpt.com/codex/tasks/task_e_685bee0c6c008321b641a0a252e21708