### PR TITLE
Fix generative API null content error

### DIFF
--- a/src/llms/__init__.py
+++ b/src/llms/__init__.py
@@ -1,2 +1,10 @@
 # Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: MIT
+
+from .llm import (
+    get_llm_by_type,
+    get_configured_llm_models,
+    SanitizedChatModel,
+)
+
+__all__ = ["get_llm_by_type", "get_configured_llm_models", "SanitizedChatModel"]

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: MIT
 
-"""
-工具函数包
-"""
+"""Utility helpers for the project."""
+
+from .message_utils import sanitize_messages
+
+__all__ = ["sanitize_messages"]

--- a/src/utils/message_utils.py
+++ b/src/utils/message_utils.py
@@ -1,0 +1,38 @@
+"""Utility functions for working with chat messages."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def sanitize_messages(messages: list) -> list:
+    """Replace ``None`` content with an empty string.
+
+    Some language model providers (e.g. the OpenAI compatible Gemini API)
+    reject messages whose ``content`` field is ``null``. Tool call messages
+    created by upstream libraries may have ``content=None`` which leads to a
+    ``400`` response (``Expected string or list of content parts, got: null``).
+    This helper normalises such messages before they are sent to the model.
+    """
+
+    sanitized: list[Any] = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            if msg.get("content") is None:
+                msg = {**msg, "content": ""}
+            sanitized.append(msg)
+            continue
+
+        content = getattr(msg, "content", None)
+        if content is None:
+            try:
+                msg.content = ""
+            except Exception:
+                try:
+                    attrs = msg.__dict__.copy()
+                    attrs["content"] = ""
+                    msg = msg.__class__(**attrs)
+                except Exception:
+                    pass
+        sanitized.append(msg)
+
+    return sanitized

--- a/tests/unit/llms/test_llm.py
+++ b/tests/unit/llms/test_llm.py
@@ -40,9 +40,10 @@ def test_get_env_llm_conf(monkeypatch):
 def test_create_llm_use_conf_merges_env(monkeypatch, dummy_conf):
     monkeypatch.setenv("BASIC_MODEL__API_KEY", "env_key")
     result = llm._create_llm_use_conf("basic", dummy_conf)
-    assert isinstance(result, DummyChatOpenAI)
-    assert result.kwargs["api_key"] == "env_key"
-    assert result.kwargs["base_url"] == "http://test"
+    assert isinstance(result, llm.SanitizedChatModel)
+    assert isinstance(result._inner, DummyChatOpenAI)
+    assert result._inner.kwargs["api_key"] == "env_key"
+    assert result._inner.kwargs["base_url"] == "http://test"
 
 
 def test_create_llm_use_conf_invalid_type(dummy_conf):
@@ -67,4 +68,6 @@ def test_get_llm_by_type_caches(monkeypatch, dummy_conf):
     inst1 = llm.get_llm_by_type("basic")
     inst2 = llm.get_llm_by_type("basic")
     assert inst1 is inst2
+    assert isinstance(inst1, llm.SanitizedChatModel)
+    assert isinstance(inst1._inner, DummyChatOpenAI)
     assert called["called"]


### PR DESCRIPTION
## Summary
- share message sanitation utility
- sanitize conversation history in graph
- wrap chat models so that null content is stripped before API calls
- expose new wrapper in llm package
- update llm tests for wrapper class

## Testing
- `make format` *(fails: Failed to download `certifi`)*
- `make lint` *(fails: Failed to download `pydantic-core`)*
- `pytest -q` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_685bf29c38188321b5381aca418bfc4b