### PR TITLE
Fix history display

### DIFF
--- a/web/src/app/chat/components/history-dialog.tsx
+++ b/web/src/app/chat/components/history-dialog.tsx
@@ -12,6 +12,7 @@ import {
 } from "~/components/ui/dialog";
 import { fetchHistory, fetchHistoryThread } from "~/core/api/history";
 import { useStore } from "~/core/store";
+import type { Message } from "~/core/messages";
 
 interface ThreadItem {
   id: string;
@@ -33,14 +34,58 @@ export function HistoryDialog() {
   const handleSelect = async (id: string) => {
     try {
       const messages = await fetchHistoryThread(id);
+
+      const messageMap = new Map<string, Message>();
+      const messageIds: string[] = [];
+      for (const m of messages) {
+        messageIds.push(m.id);
+        messageMap.set(m.id, { ...m });
+      }
+
+      const researchIds: string[] = [];
+      const researchPlanIds = new Map<string, string>();
+      const researchReportIds = new Map<string, string>();
+      const researchActivityIds = new Map<string, string[]>();
+
+      let lastPlanner: string | null = null;
+      let currentResearch: string | null = null;
+
+      for (const m of messages) {
+        if (m.agent === "planner") {
+          lastPlanner = m.id;
+        } else if (
+          m.agent === "coder" ||
+          m.agent === "researcher" ||
+          m.agent === "reporter"
+        ) {
+          if (!currentResearch) {
+            currentResearch = m.id;
+            researchIds.push(currentResearch);
+            const ids = [] as string[];
+            if (lastPlanner) {
+              researchPlanIds.set(currentResearch, lastPlanner);
+              ids.push(lastPlanner);
+            }
+            ids.push(m.id);
+            researchActivityIds.set(currentResearch, ids);
+          } else {
+            researchActivityIds.get(currentResearch)?.push(m.id);
+          }
+          if (m.agent === "reporter") {
+            researchReportIds.set(currentResearch, m.id);
+            currentResearch = null;
+          }
+        }
+      }
+
       useStore.setState({
         threadId: id,
-        messageIds: messages.map((m) => m.id),
-        messages: new Map(messages.map((m) => [m.id, m])),
-        researchIds: [],
-        researchPlanIds: new Map(),
-        researchReportIds: new Map(),
-        researchActivityIds: new Map(),
+        messageIds,
+        messages: messageMap,
+        researchIds,
+        researchPlanIds,
+        researchReportIds,
+        researchActivityIds,
         ongoingResearchId: null,
         openResearchId: null,
       });

--- a/web/src/core/store/store.ts
+++ b/web/src/core/store/store.ts
@@ -408,7 +408,13 @@ async function persistHistory() {
   const messages = state.messageIds
     .map((id) => state.messages.get(id))
     .filter((m): m is Message => m !== undefined);
-  const title = messages.find((m) => m.agent === "planner")?.content ?? "";
+  const plannerContent = messages.find((m) => m.agent === "planner")?.content ?? "";
+  let title = "";
+  try {
+    title = JSON.parse(plannerContent).title ?? "";
+  } catch {
+    title = plannerContent;
+  }
   try {
     await saveHistory(state.threadId, title, messages);
   } catch (e) {


### PR DESCRIPTION
## Summary
- show threads with correct titles when planner content is JSON
- restore research data when loading a thread from history

## Testing
- `pytest -o addopts='' tests/unit/server/test_history.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685c969a66b48321b4e3ebe41ae830ef